### PR TITLE
TRANS-9527 / PDFBOX-5191 Workiva review PR

### DIFF
--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -75,6 +75,12 @@
             <artifactId>jbig2-imageio</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
         <!-- For legal reasons (incompatible license), these three dependencies below
         are to be used only in the tests and may not be distributed. 
         See also LEGAL-195 -->

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
@@ -142,14 +142,7 @@ abstract class TrueTypeEmbedder implements Subsetter
         {
             int fsType = ttf.getOS2Windows().getFsType();
             int maskedFsType = fsType & 0x000F;
-            // use two's complement arithmetic to check if fsType is a power of 2
-            // all legal fsType combinations for fonts having a version 3 OS2 table are powers of 2
-            // there are more legal combinations for versions 0-2, but the most permissive pit takes precedence
-            boolean powerOfTwo = maskedFsType != 0 && (maskedFsType & (maskedFsType - 1)) == 0;
-            if (
-                    powerOfTwo &&
-                    (fsType & OS2WindowsMetricsTable.FSTYPE_RESTRICTED) == OS2WindowsMetricsTable.FSTYPE_RESTRICTED
-            )
+            if (maskedFsType == OS2WindowsMetricsTable.FSTYPE_RESTRICTED)
             {
                 // restricted License embedding
                 return false;

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
@@ -136,7 +136,7 @@ abstract class TrueTypeEmbedder implements Subsetter
     /**
      * Returns true if the fsType in the OS/2 table permits embedding.
      */
-    private boolean isEmbeddingPermitted(TrueTypeFont ttf) throws IOException
+    protected boolean isEmbeddingPermitted(TrueTypeFont ttf) throws IOException
     {
         if (ttf.getOS2Windows() != null)
         {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
@@ -141,8 +141,9 @@ abstract class TrueTypeEmbedder implements Subsetter
         if (ttf.getOS2Windows() != null)
         {
             int fsType = ttf.getOS2Windows().getFsType();
+            int maskedFsType = fsType & 0x000F;
             // use two's complement arithmetic to check if fsType is a power of 2
-            boolean powerOfTwo = fsType != 0 && (fsType & (fsType - 1)) == 0;
+            boolean powerOfTwo = maskedFsType != 0 && (maskedFsType & (maskedFsType - 1)) == 0;
             if (
                     powerOfTwo &&
                     (fsType & OS2WindowsMetricsTable.FSTYPE_RESTRICTED) == OS2WindowsMetricsTable.FSTYPE_RESTRICTED

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
@@ -141,8 +141,12 @@ abstract class TrueTypeEmbedder implements Subsetter
         if (ttf.getOS2Windows() != null)
         {
             int fsType = ttf.getOS2Windows().getFsType();
-            if ((fsType & OS2WindowsMetricsTable.FSTYPE_RESTRICTED) ==
-                             OS2WindowsMetricsTable.FSTYPE_RESTRICTED)
+            // use two's complement arithmetic to check if fsType is a power of 2
+            boolean powerOfTwo = fsType != 0 && (fsType & (fsType - 1)) == 0;
+            if (
+                    powerOfTwo &&
+                    (fsType & OS2WindowsMetricsTable.FSTYPE_RESTRICTED) == OS2WindowsMetricsTable.FSTYPE_RESTRICTED
+            )
             {
                 // restricted License embedding
                 return false;

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
@@ -136,7 +136,7 @@ abstract class TrueTypeEmbedder implements Subsetter
     /**
      * Returns true if the fsType in the OS/2 table permits embedding.
      */
-    protected boolean isEmbeddingPermitted(TrueTypeFont ttf) throws IOException
+    boolean isEmbeddingPermitted(TrueTypeFont ttf) throws IOException
     {
         if (ttf.getOS2Windows() != null)
         {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/TrueTypeEmbedder.java
@@ -143,6 +143,8 @@ abstract class TrueTypeEmbedder implements Subsetter
             int fsType = ttf.getOS2Windows().getFsType();
             int maskedFsType = fsType & 0x000F;
             // use two's complement arithmetic to check if fsType is a power of 2
+            // all legal fsType combinations for fonts having a version 3 OS2 table are powers of 2
+            // there are more legal combinations for versions 0-2, but the most permissive pit takes precedence
             boolean powerOfTwo = maskedFsType != 0 && (maskedFsType & (maskedFsType - 1)) == 0;
             if (
                     powerOfTwo &&

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
@@ -381,7 +381,6 @@ class TestFontEmbedding
         /**
          * Common functionality for testing the TrueTypeFontEmbedder
          *
-         * @author Larry Lynn
          */
         TrueTypeEmbedderTester(PDDocument document, COSDictionary dict, TrueTypeFont ttf, boolean embedSubset) throws IOException {
             super(document, dict, ttf, embedSubset);
@@ -395,7 +394,7 @@ class TestFontEmbedding
     }
 
     /**
-     * XXX Populate Me
+     * Test that we validate embedding permissions properly for all legal permissions combinations
      *
      * @throws IOException
      */

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
@@ -17,9 +17,6 @@
 
 package org.apache.pdfbox.pdmodel.font;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -28,6 +25,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.fontbox.ttf.OS2WindowsMetricsTable;
+import org.apache.fontbox.ttf.TTFParser;
 import org.apache.fontbox.ttf.TrueTypeFont;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSArray;
@@ -44,6 +43,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 /**
  * Tests font embedding.
@@ -403,12 +406,18 @@ class TestFontEmbedding
         PDDocument doc = new PDDocument();
         COSDictionary cosDictionary = new COSDictionary();
         InputStream input = PDFont.class.getResourceAsStream("/org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf");
-        TrueTypeFont ttf = new TrueTypeFont(input);
-
-        TrueTypeEmbedderTester tester = new TrueTypeEmbedderTester(doc, cosDictionary, XXX, true);
+        TrueTypeFont ttf = new TTFParser().parseEmbedded(input);
+        TrueTypeEmbedderTester tester = new TrueTypeEmbedderTester(doc, cosDictionary, ttf, true);
+        TrueTypeFont mockTtf = Mockito.mock(TrueTypeFont.class);
+        OS2WindowsMetricsTable mockOS2 = Mockito.mock(OS2WindowsMetricsTable.class);
+        given(mockTtf.getOS2Windows()).willReturn(mockOS2);
+        Boolean embeddingIsPermitted;
 
         // TEST
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x0002);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
 
         // VERIFY
+        assertFalse(embeddingIsPermitted);
     }
 }

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
@@ -25,8 +25,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.fontbox.ttf.TrueTypeFont;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSDictionary;
@@ -370,5 +372,43 @@ class TestFontEmbedding
             String extractedText = stripper.getText(document);
             assertEquals(text1 + " " + text2, extractedText.trim());
         }
+    }
+
+    private class TrueTypeEmbedderTester extends TrueTypeEmbedder {
+        /**
+         * Common functionality for testing the TrueTypeFontEmbedder
+         *
+         * @author Larry Lynn
+         */
+        TrueTypeEmbedderTester(PDDocument document, COSDictionary dict, TrueTypeFont ttf, boolean embedSubset) throws IOException {
+            super(document, dict, ttf, embedSubset);
+        }
+
+        @Override
+        protected void buildSubset(InputStream ttfSubset, String tag, Map<Integer, Integer> gidToCid) throws IOException {
+            // no-op.  Need to define method to extend abstract class, but
+            // this method is not currently needed for testing
+        }
+    }
+
+    /**
+     * XXX Populate Me
+     *
+     * @throws IOException
+     */
+    @Test
+    void testIsEmbeddingPermittedMultipleVersons() throws IOException
+    {
+        // SETUP
+        PDDocument doc = new PDDocument();
+        COSDictionary cosDictionary = new COSDictionary();
+        InputStream input = PDFont.class.getResourceAsStream("/org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf");
+        TrueTypeFont ttf = new TrueTypeFont(input);
+
+        TrueTypeEmbedderTester tester = new TrueTypeEmbedderTester(doc, cosDictionary, XXX, true);
+
+        // TEST
+
+        // VERIFY
     }
 }

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java
@@ -413,11 +413,80 @@ class TestFontEmbedding
         given(mockTtf.getOS2Windows()).willReturn(mockOS2);
         Boolean embeddingIsPermitted;
 
-        // TEST
+        // TEST 1: 0000 -- Installable embedding versions 0-3+
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x0000);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
+
+        // VERIFY
+        assertTrue(embeddingIsPermitted);
+
+        // no test for 0001, since bit 0 is permanently reserved, and its use is deprecated
+
+        // TEST 2: 0010 -- Restricted License embedding versions 0-3+
         given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x0002);
         embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
 
         // VERIFY
         assertFalse(embeddingIsPermitted);
+
+        // no test for 0011
+
+        // TEST 3: 0100 -- Preview & Print embedding versions 0-3+
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x0004);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
+
+        // VERIFY
+        assertTrue(embeddingIsPermitted);
+
+        // no test for 0101
+
+        // TEST 4: 0110 -- Restricted License embedding AND Preview & Print embedding versions 0-2
+        //              -- illegal permissions combination for versions 3+
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x0006);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
+
+        // VERIFY
+        assertTrue(embeddingIsPermitted);
+
+        // no test for 0111
+
+        // TEST 5: 1000 -- Editable embedding versions 0-3+
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x0008);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
+
+        // VERIFY
+        assertTrue(embeddingIsPermitted);
+
+        // no test for 1001
+
+        // TEST 6: 1010 -- Restricted License embedding AND Editable embedding versions 0-2
+        //              -- illegal permissions combination for versions 3+
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x000A);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
+
+        // VERIFY
+        assertTrue(embeddingIsPermitted);
+
+        // no test for 1011
+
+        // TEST 7: 1100 -- Editable embedding AND Preview & Print embedding versions 0-2
+        //              -- illegal permissions combination for versions 3+
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x000C);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
+
+        // VERIFY
+        assertTrue(embeddingIsPermitted);
+
+        // no test for 1101
+
+        // TEST 8: 1110 Editable embedding AND Preview & Print embedding AND Restricted License embedding versions 0-2
+        //              -- illegal permissions combination for versions 3+
+        given( mockTtf.getOS2Windows().getFsType() ).willReturn((short) 0x000E);
+        embeddingIsPermitted = tester.isEmbeddingPermitted(mockTtf);
+
+        // VERIFY
+        assertTrue(embeddingIsPermitted);
+
+        // no test for 1111
     }
 }


### PR DESCRIPTION
JIRA: https://jira.atl.workiva.net/browse/TRANS-9527

### PROBLEM
New versions of pdfbox are too restrictive and refuse to embed some of our fonts

### SOLUTION
tweak the isEmbeddingPermitted() method to return the proper boolean when multiple permission bits are set (like 0110 = 6).  Add unit tests to exercise all legal permission combinations

### +10 / QA
1) ```git clone git@github.com:larrylynn-wf/pdfbox.git```
2) ```git checkout PDFBOX-5191```
3) open that codebase in IntelliJ
4) run my new test in pdfbox/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/font/TestFontEmbedding.java in the IDE
5) confirm that test passes (exercises my bugfix with multiple variations of font permissions)
4 & 5 alternate) ```mvn test``` to run all of the tests including my new one.  You'll probably have to comment out a test.  I was getting a failure on a clean checkout of the 2.0.23 tag that I think is related to cross platform differences in processing in an unrelated part of the codebase.
6) ```git checkout PDFBOX-5191-testing```.  This testing code is branched off of the 2.0.23 tag.  I ported over just the bugfix but not the tests because the test framework on the 3.0.x codebase differs drastically from that of the 2.0.x codebase.  My tests don't work and break stuff on 2.0.x.  For visualization purposes, here's a link to a draft PR showing the testing code: https://github.com/larrylynn-wf/pdfbox/pull/2
7) ```mvn package```
8) now install some of the new packages locally to make them available to wtranslate.
9) ```mvn install:install-file -Dfile=./pdfbox/target/pdfbox-2.0.23.jar -DgroupId=org.apache.pdfbox  -DartifactId=pdfbox -Dversion=2.0.23 -Dpackaging=jar -Dgeneration=true -DgeneratePom=true```
10) ```mvn install:install-file -Dfile=./fontbox/target/fontbox-2.0.23.jar -DgroupId=org.apache.pdfbox  -DartifactId=fontbox -Dversion=2.0.23 -Dpackaging=jar -Dgeneration=true -DgeneratePom=true```
11) You may need to do a similar install for the xmpbox lib.  I'm not sure about that one.  I can show you how to do that if needed.
12) now jump over to your wTranslate checkout and pull in the updated libraries.
13) edit pom.xml in the subservice.  bump the version of pdfbox we're specifying to 2.0.23
14) edit pom.xml and add a new dependency for fontbox
```
        <dependency>
            <groupId>org.apache.pdfbox</groupId>
            <artifactId>fontbox</artifactId>
            <version>2.0.23</version>
        </dependency>
```
I think we need this because when we're building normally, maven pulls fontbox in as a transitive dependency of pdfbox.  But when we're using a local copy of pdfbox, it doesn't go out and pull in the transitive dependency over the network from artifactory, it looks for a local dependency instead.
15) ```make init```.  If you've built recently, you might be able to get away with just ```make buildjava```
16) ```go run client_app/v2/client.go -in document -out pdf -timeout=300s ./testdata/document/fontDoc.document```
That document is the document which detected the font embedding regression in pdfbox 2.0.23.  It threw an unhandled exception and terminated processing, so you didn't get a PDF out.  If this command terminates normally, it means that my code is effective in fixing the font permission validation that was too restrictive.
17) open the PDF and look for the section that uses ArialRoundedMTBold.ttf - confirm that it looks reasonable, that it looks like it's using the right font, doesn't get tofu or some obvious fallback font.

- [ ] If gold files have been updated in PR please merge master to confirm no conflicts (git pull origin master)

### ADDITIONAL TESTING
- [ ] External testing required (EDGAR, XBRL, SOX, etc.)
- [ ] If required please reach out to jim.ellwood@workiva.com via email/slack for test coverage
- [ ] Deployment (wk-dev) required (Excel export *must* be tested in wk-dev)

### AUTOMATED TESTS
Describe the automated tests you added. If none were added, explain why.

### SEMANTIC VERSIONING
**Patch**
- [ ] This change fixes existing incorrect behavior without any additions to the public API
- [ ] This change modifies developer tools or does not otherwise affect behavior

**Minor**
- [ ] This change adds something to the public API
- [ ] This change deprecates a part of the public API
- [ ] This change adds support for a new feature

**Major**
- [ ] This change modifies part of the public API in a backwards-incompatible manner
- [ ] This change removes part of the public API
